### PR TITLE
add autocmd to match OverLength in all windows

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -58,6 +58,7 @@ setlocal spelllang=en_us
 set colorcolumn=80
 highlight OverLength ctermbg=red ctermfg=white guibg=#592929
 match OverLength /\%81v.\+/
+autocmd WinEnter * match OverLength /\%81v.\+/
 
 "gVim-specific configurations (including MacVim).
 if has("gui_running")


### PR DESCRIPTION
http://stackoverflow.com/questions/11158806/vim-new-tabbed-pages-dont-match-text
